### PR TITLE
feat: Add Settings Link to Plugin List Page

### DIFF
--- a/assets/js/admin-settings.js
+++ b/assets/js/admin-settings.js
@@ -1,0 +1,40 @@
+jQuery(document).ready(function ($) {
+    // JS Optimizations
+    const jsToggle = $('#rt_optimizer_disable_js_optimizations');
+    const jsSubOptions = jsToggle.closest('tr').nextAll();
+
+    function toggleJsOptions() {
+        if (jsToggle.is(':checked')) {
+            jsSubOptions.css('opacity', '0.5');
+            jsSubOptions.find('input, textarea, select').prop('disabled', true);
+        } else {
+            jsSubOptions.css('opacity', '1');
+            jsSubOptions
+                .find('input, textarea, select')
+                .prop('disabled', false);
+        }
+    }
+
+    jsToggle.on('change', toggleJsOptions);
+    toggleJsOptions();
+
+    // CSS Optimizations
+    const cssToggle = $('#rt_optimizer_disable_css_optimizations');
+    const cssSubOptions = cssToggle.closest('tr').nextAll();
+
+    function toggleCssOptions() {
+        if (cssToggle.is(':checked')) {
+            cssSubOptions.css('opacity', '0.5');
+            cssSubOptions
+                .find('input, textarea, select')
+                .prop('disabled', true);
+        } else {
+            cssSubOptions.css('opacity', '1');
+            cssSubOptions
+                .find('input, textarea, select')
+                .prop('disabled', false);
+        }
+    }
+    cssToggle.on('change', toggleCssOptions);
+    toggleCssOptions();
+});

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -23,9 +23,9 @@ function rt_settings_init()
 	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_load_amp_boilerplate_style');
 	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_skip_css_concatination_all');
 	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_skip_css_concatination_handles');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_comment_out_style_handles');
 	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_disable_js_optimizations');
 	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_disable_css_optimizations');
-	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_comment_out_style_handles');
 
 	// Register a new section for JS optimizations.
 	add_settings_section(
@@ -118,7 +118,7 @@ function rt_settings_init()
 	// Register a new field to fetch option whether to skip all CSS concatination.
 	add_settings_field(
 		'rt_scripts_optimizer_skip_css_concatination_all',
-		__('Skip all CSS concatenation', 'RT_Script_Optimizer'),
+		__('Skip all CSS concatination', 'RT_Script_Optimizer'),
 		'rt_scripts_optimizer_skip_css_concatination_all_callback',
 		'rt-scripts-optimizer-settings',
 		'rt_scripts_optimizer_css_settings_section'
@@ -127,7 +127,7 @@ function rt_settings_init()
 	// Register a new field to fetch handles of stylesheets which are not to be concated.
 	add_settings_field(
 		'rt_scripts_optimizer_skip_css_concatination_handles',
-		__('Skip CSS concatenation for these handles', 'RT_Script_Optimizer'),
+		__('Skip CSS concatination for these handles', 'RT_Script_Optimizer'),
 		'rt_scripts_optimizer_skip_css_concatination_handles_callback',
 		'rt-scripts-optimizer-settings',
 		'rt_scripts_optimizer_css_settings_section'
@@ -351,6 +351,76 @@ function rt_scripts_optimizer_skip_css_concatination_handles_callback($args)
 <?php
 }
 
+/**
+ * Field callback to accept handles of stylesheets to be commented out.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_comment_out_style_handles_callback($args)
+{
+
+	// option value.
+	$handles = get_option('rt_scripts_optimizer_comment_out_style_handles');
+?>
+
+	<input type="text"
+		id="rt_optimizer_comment_out_style_handles"
+		name="rt_scripts_optimizer_comment_out_style_handles"
+		value="<?php echo esc_attr($handles); ?>"
+		style="width:80%;">
+
+	<br>
+
+	<p class='description'>
+		<?php esc_html_e('Adding stylesheets\' handles here will comment them out in the HTML, preventing them from loading.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
+}
+
+/**
+ * Field callback to disable JS optimizations.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_disable_js_optimizations_callback($args)
+{
+
+	// option value.
+	$disable_js_optimizations = get_option('rt_scripts_optimizer_disable_js_optimizations', '1');
+?>
+
+	<input type="checkbox" id="rt_optimizer_disable_js_optimizations" name="rt_scripts_optimizer_disable_js_optimizations" value="1" <?php checked($disable_js_optimizations, '1', true); ?>>
+
+	<br>
+
+	<p class='description'>
+		<?php esc_html_e('Check this if you want to disable all JS optimizations.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
+}
+
+/**
+ * Field callback to disable CSS optimizations.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_disable_css_optimizations_callback($args)
+{
+
+	// option value.
+	$disable_css_optimizations = get_option('rt_scripts_optimizer_disable_css_optimizations', '1');
+?>
+
+	<input type="checkbox" id="rt_optimizer_disable_css_optimizations" name="rt_scripts_optimizer_disable_css_optimizations" value="1" <?php checked($disable_css_optimizations, '1', true); ?>>
+
+	<br>
+
+	<p class='description'>
+		<?php esc_html_e('Check this if you want to disable all CSS optimizations.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
+}
+
 
 
 /**
@@ -375,66 +445,6 @@ function rt_scripts_optimizer_paths_field_callback($args)
 
 	<p class='description'>
 		<?php esc_html_e('Adding script path to this field will exclude them from optimizer and load them normally.', 'RT_Script_Optimizer'); ?>
-	</p>
-<?php
-}
-
-/**
- * Field callback to disable JS optimizations.
- *
- * @param array $args arguments passed.
- */
-function rt_scripts_optimizer_disable_js_optimizations_callback($args)
-{
-
-	// option value.
-	$disable_js_optimizations = get_option('rt_scripts_optimizer_disable_js_optimizations', '1');
-?>
-
-	<input type="checkbox" id="rt_optimizer_disable_js_optimizations" name="rt_scripts_optimizer_disable_js_optimizations" value="1" <?php checked($disable_js_optimizations, '1', true); ?>>
-	<p class='description'>
-		<?php esc_html_e('Check this to disable all JS optimizations.', 'RT_Script_Optimizer'); ?>
-	</p>
-<?php
-}
-
-/**
- * Field callback to disable CSS optimizations.
- *
- * @param array $args arguments passed.
- */
-function rt_scripts_optimizer_disable_css_optimizations_callback($args)
-{
-
-	// option value.
-	$disable_css_optimizations = get_option('rt_scripts_optimizer_disable_css_optimizations', '1');
-?>
-
-	<input type="checkbox" id="rt_optimizer_disable_css_optimizations" name="rt_scripts_optimizer_disable_css_optimizations" value="1" <?php checked($disable_css_optimizations, '1', true); ?>>
-	<p class='description'>
-		<?php esc_html_e('Check this to disable all CSS optimizations.', 'RT_Script_Optimizer'); ?>
-	</p>
-<?php
-}
-
-/**
- * Field callback to accept handles of stylesheets which are to be commented out.
- *
- * @param array $args arguments passed.
- */
-function rt_scripts_optimizer_comment_out_style_handles_callback($args)
-{
-
-	// option value.
-	$handles = get_option('rt_scripts_optimizer_comment_out_style_handles');
-?>
-
-	<input type="text" id="rt_optimizer_comment_out_style_handles" name="rt_scripts_optimizer_comment_out_style_handles" value="<?php echo esc_attr($handles); ?>" style="width:80%;">
-
-	<br>
-
-	<p class='description'>
-		<?php esc_html_e('Adding stylesheets\' handle here will make them be commented out in the HTML.', 'RT_Script_Optimizer'); ?>
 	</p>
 <?php
 }

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Setting Options page for rt-scripts-optimizer plugin.
  *
@@ -10,116 +11,170 @@
 /**
  * Custom option's and settings
  */
-function rt_settings_init() {
+function rt_settings_init()
+{
 
 	// Register new setting options.
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_paths' );
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_handles' );
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_style_dequeue_non_logged_handles' );
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_style_async_handles' );
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_style_async_handles_onevent' );
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_load_amp_boilerplate_style' );
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_skip_css_concatination_all' );
-	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_skip_css_concatination_handles' );
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_paths');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_handles');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_style_dequeue_non_logged_handles');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_style_async_handles');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_style_async_handles_onevent');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_load_amp_boilerplate_style');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_skip_css_concatination_all');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_skip_css_concatination_handles');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_disable_js_optimizations');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_disable_css_optimizations');
+	register_setting('rt-scripts-optimizer-settings', 'rt_scripts_optimizer_comment_out_style_handles');
 
-	// Register a new section.
+	// Register a new section for JS optimizations.
 	add_settings_section(
-		'rt_scripts_optimizer_settings_section',                            // ID.
-		__( 'RT Scripts Optimizer Settings', 'RT_Script_Optimizer' ),        // Title.
-		'rt_scripts_optimizer_settings_callback',                           // Callback Function.
-		'rt-scripts-optimizer-settings'                                     // Page.
+		'rt_scripts_optimizer_js_settings_section',
+		__('JavaScript Optimizations', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_js_settings_callback',
+		'rt-scripts-optimizer-settings'
+	);
+
+	// Register a new field to disable JS optimizations.
+	add_settings_field(
+		'rt_scripts_optimizer_disable_js_optimizations',
+		__('Disable JS Optimizations', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_disable_js_optimizations_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_js_settings_section'
 	);
 
 	// Register a new field to fetch paths of scripts to exclude.
 	add_settings_field(
-		'rt_scripts_optimizer_path_field',                              // As of WP 4.6 this value is used only internally.
-		__( 'Load js normally by adding script path here', 'RT_Script_Optimizer' ),                    // Title.
-		'rt_scripts_optimizer_paths_field_callback',                    // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_path_field',
+		__('Load js normally by adding script path here', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_paths_field_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_js_settings_section'
 	);
 
 	// Register a new field to fetch handles of scripts to exclude.
 	add_settings_field(
-		'rt_scripts_optimizer_handle_field',                            // As of WP 4.6 this value is used only internally.
-		__( 'Load js normally by adding script handles', 'RT_Script_Optimizer' ),                  // Title.
-		'rt_scripts_optimizer_handles_field_callback',                  // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_handle_field',
+		__('Load js normally by adding script handles', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_handles_field_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_js_settings_section'
+	);
+
+	// Register a new section for CSS optimizations.
+	add_settings_section(
+		'rt_scripts_optimizer_css_settings_section',
+		__('CSS Optimizations', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_css_settings_callback',
+		'rt-scripts-optimizer-settings'
+	);
+
+	// Register a new field to disable CSS optimizations.
+	add_settings_field(
+		'rt_scripts_optimizer_disable_css_optimizations',
+		__('Disable CSS Optimizations', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_disable_css_optimizations_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
 	);
 
 	// Register a new field to fetch handles of styles to be dequeued for non-logged in users.
 	add_settings_field(
-		'rt_scripts_optimizer_style_dequeue_non_logged_handles',                            // As of WP 4.6 this value is used only internally.
-		__( 'CSS handles of the stylesheets which should not be loaded if user not logged in', 'RT_Script_Optimizer' ),                  // Title.
-		'rt_scripts_optimizer_style_dequeue_non_logged_handles_callback',                  // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_style_dequeue_non_logged_handles',
+		__('CSS handles of the stylesheets which should not be loaded if user not logged in', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_style_dequeue_non_logged_handles_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
 	);
 
 	// Register a new field to fetch handles of styles to be loaded async.
 	add_settings_field(
-		'rt_scripts_optimizer_style_async_handles',                            // As of WP 4.6 this value is used only internally.
-		__( 'CSS handles of the stylesheets which should be asynchronously loaded', 'RT_Script_Optimizer' ),                  // Title.
-		'rt_scripts_optimizer_style_async_handles_callback',                  // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_style_async_handles',
+		__('CSS handles of the stylesheets which should be asynchronously loaded', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_style_async_handles_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
 	);
 
 	// Register a new field to fetch handles of styles to be loaded on any window event.
 	add_settings_field(
-		'rt_scripts_optimizer_style_async_handles_onevent',                            // As of WP 4.6 this value is used only internally.
-		__( 'CSS handles of the stylesheets which should be asynchronously loaded on any window event', 'RT_Script_Optimizer' ),                  // Title.
-		'rt_scripts_optimizer_style_async_handles_onevent_callback',                  // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_style_async_handles_onevent',
+		__('CSS handles of the stylesheets which should be asynchronously loaded on any window event', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_style_async_handles_onevent_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
 	);
 
 	// Register a new field to fetch option whether to load amp-boilerplate style.
 	add_settings_field(
-		'rt_scripts_optimizer_load_amp_boilerplate_style',                            // As of WP 4.6 this value is used only internally.
-		__( 'Load AMP boilerplate CSS', 'RT_Script_Optimizer' ),                  // Title.
-		'rt_scripts_optimizer_load_amp_boilerplate_style_callback',                  // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_load_amp_boilerplate_style',
+		__('Load AMP boilerplate CSS', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_load_amp_boilerplate_style_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
 	);
 
 	// Register a new field to fetch option whether to skip all CSS concatination.
 	add_settings_field(
-		'rt_scripts_optimizer_skip_css_concatination_all',                            // As of WP 4.6 this value is used only internally.
-		__( 'Skip all CSS concatination', 'RT_Script_Optimizer' ),                  // Title.
-		'rt_scripts_optimizer_skip_css_concatination_all_callback',                  // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_skip_css_concatination_all',
+		__('Skip all CSS concatenation', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_skip_css_concatination_all_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
 	);
 
 	// Register a new field to fetch handles of stylesheets which are not to be concated.
 	add_settings_field(
-		'rt_scripts_optimizer_skip_css_concatination_handles',                            // As of WP 4.6 this value is used only internally.
-		__( 'Skip CSS concatination for these handles', 'RT_Script_Optimizer' ),                  // Title.
-		'rt_scripts_optimizer_skip_css_concatination_handles_callback',                  // Callback Function.
-		'rt-scripts-optimizer-settings',                                // Page.
-		'rt_scripts_optimizer_settings_section'                         // Section.
+		'rt_scripts_optimizer_skip_css_concatination_handles',
+		__('Skip CSS concatenation for these handles', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_skip_css_concatination_handles_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
+	);
+
+	// Register a new field to fetch handles of stylesheets which are to be commented out.
+	add_settings_field(
+		'rt_scripts_optimizer_comment_out_style_handles',
+		__('Comment out CSS by handle', 'RT_Script_Optimizer'),
+		'rt_scripts_optimizer_comment_out_style_handles_callback',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_css_settings_section'
 	);
 }
 
 /**
  * Register settings to the admin_init action hook.
  */
-add_action( 'admin_init', 'rt_settings_init' );
-
+add_action('admin_init', 'rt_settings_init');
 
 /**
- * Section Description callback.
+ * JS Section Description callback.
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_settings_callback( $args ) {
-	?>
-		<p>
-			<?php esc_html_e( 'Add scripts to exclude from the RT Scripts Optimizer by providing it\'s handle or path.', 'RT_Script_Optimizer' ); ?>
-		</p>
-	<?php
+function rt_scripts_optimizer_js_settings_callback($args)
+{
+?>
+	<p>
+		<?php esc_html_e('Control JavaScript optimization settings. You can disable all JS optimizations using the master switch below.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
+}
+
+/**
+ * CSS Section Description callback.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_css_settings_callback($args)
+{
+?>
+	<hr />
+	<p>
+		<?php esc_html_e('Control CSS optimization settings. You can disable all CSS optimizations using the master switch below.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
 }
 
 /**
@@ -127,25 +182,25 @@ function rt_scripts_optimizer_settings_callback( $args ) {
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_handles_field_callback( $args ) {
+function rt_scripts_optimizer_handles_field_callback($args)
+{
 
 	// option value.
-	$handles = get_option( 'rt_scripts_optimizer_exclude_handles' );
-	?>
+	$handles = get_option('rt_scripts_optimizer_exclude_handles');
+?>
 
 	<input type="text"
 		id="rt_optimizer_handles"
 		name="rt_scripts_optimizer_exclude_handles"
-		value="<?php echo esc_attr( $handles ); ?>"
-		style="width:80%;"
-	>
+		value="<?php echo esc_attr($handles); ?>"
+		style="width:80%;">
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Adding script handles to this field will exclude them from optimizer and load them normally.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Adding script handles to this field will exclude them from optimizer and load them normally.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
 }
 
 /**
@@ -153,25 +208,25 @@ function rt_scripts_optimizer_handles_field_callback( $args ) {
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_style_dequeue_non_logged_handles_callback( $args ) {
+function rt_scripts_optimizer_style_dequeue_non_logged_handles_callback($args)
+{
 
 	// option value.
-	$paths = get_option( 'rt_scripts_optimizer_style_dequeue_non_logged_handles' );
-	?>
+	$paths = get_option('rt_scripts_optimizer_style_dequeue_non_logged_handles');
+?>
 
 	<input type="text"
 		id="rt_optimizer_style_dequeue_non_logged_handles"
 		name="rt_scripts_optimizer_style_dequeue_non_logged_handles"
-		value="<?php echo esc_attr( $paths ); ?>"
-		style="width:80%;"
-	>
+		value="<?php echo esc_attr($paths); ?>"
+		style="width:80%;">
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Adding stylesheets\' handles here will make them be dequeued when user not logged in.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Adding stylesheets\' handles here will make them be dequeued when user not logged in.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
 }
 
 /**
@@ -179,25 +234,25 @@ function rt_scripts_optimizer_style_dequeue_non_logged_handles_callback( $args )
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_style_async_handles_callback( $args ) {
+function rt_scripts_optimizer_style_async_handles_callback($args)
+{
 
 	// option value.
-	$paths = get_option( 'rt_scripts_optimizer_style_async_handles' );
-	?>
+	$paths = get_option('rt_scripts_optimizer_style_async_handles');
+?>
 
 	<input type="text"
 		id="rt_optimizer_style_async_handles"
 		name="rt_scripts_optimizer_style_async_handles"
-		value="<?php echo esc_attr( $paths ); ?>"
-		style="width:80%;"
-	>
+		value="<?php echo esc_attr($paths); ?>"
+		style="width:80%;">
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Adding stylesheets\' handle here will make them load asynchronously automatically.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Adding stylesheets\' handle here will make them load asynchronously automatically.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
 }
 
 /**
@@ -205,25 +260,25 @@ function rt_scripts_optimizer_style_async_handles_callback( $args ) {
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_style_async_handles_onevent_callback( $args ) {
+function rt_scripts_optimizer_style_async_handles_onevent_callback($args)
+{
 
 	// option value.
-	$paths = get_option( 'rt_scripts_optimizer_style_async_handles_onevent' );
-	?>
+	$paths = get_option('rt_scripts_optimizer_style_async_handles_onevent');
+?>
 
 	<input type="text"
 		id="rt_optimizer_style_async_on_event_handles"
 		name="rt_scripts_optimizer_style_async_handles_onevent"
-		value="<?php echo esc_attr( $paths ); ?>"
-		style="width:80%;"
-	>
+		value="<?php echo esc_attr($paths); ?>"
+		style="width:80%;">
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Adding stylesheets\' handle here will make them load asynchronously on windows event.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Adding stylesheets\' handle here will make them load asynchronously on windows event.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
 }
 
 /**
@@ -231,20 +286,21 @@ function rt_scripts_optimizer_style_async_handles_onevent_callback( $args ) {
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_load_amp_boilerplate_style_callback( $args ) {
+function rt_scripts_optimizer_load_amp_boilerplate_style_callback($args)
+{
 
 	// option value.
-	$load_amp_css = get_option( 'rt_scripts_optimizer_load_amp_boilerplate_style' );
-	?>
+	$load_amp_css = get_option('rt_scripts_optimizer_load_amp_boilerplate_style');
+?>
 
-	<input type="checkbox" id="rt_optimizer_load_amp_css" name="rt_scripts_optimizer_load_amp_boilerplate_style" value="1" <?php checked( $load_amp_css, '1', true ); ?>>
+	<input type="checkbox" id="rt_optimizer_load_amp_css" name="rt_scripts_optimizer_load_amp_boilerplate_style" value="1" <?php checked($load_amp_css, '1', true); ?>>
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Check this if you want to load AMP boilerplate CSS to avoid CLS issue.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Check this if you want to load AMP boilerplate CSS to avoid CLS issue.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
 }
 
 /**
@@ -252,20 +308,21 @@ function rt_scripts_optimizer_load_amp_boilerplate_style_callback( $args ) {
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_skip_css_concatination_all_callback( $args ) {
+function rt_scripts_optimizer_skip_css_concatination_all_callback($args)
+{
 
 	// option value.
-	$skip_css_concatination = get_option( 'rt_scripts_optimizer_skip_css_concatination_all' );
-	?>
+	$skip_css_concatination = get_option('rt_scripts_optimizer_skip_css_concatination_all');
+?>
 
-	<input type="checkbox" id="rt_optimizer_skip_css_concatination_all" name="rt_scripts_optimizer_skip_css_concatination_all" value="1" <?php checked( $skip_css_concatination, '1', true ); ?>>
+	<input type="checkbox" id="rt_optimizer_skip_css_concatination_all" name="rt_scripts_optimizer_skip_css_concatination_all" value="1" <?php checked($skip_css_concatination, '1', true); ?>>
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Check this if you want to disable CSS concatination completely. If this is checked then the below field have no effect.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Check this if you want to disable CSS concatenation completely. If this is checked then the below field have no effect.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
 }
 
 /**
@@ -273,102 +330,261 @@ function rt_scripts_optimizer_skip_css_concatination_all_callback( $args ) {
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_skip_css_concatination_handles_callback( $args ) {
+function rt_scripts_optimizer_skip_css_concatination_handles_callback($args)
+{
 
 	// option value.
-	$handles = get_option( 'rt_scripts_optimizer_skip_css_concatination_handles' );
-	?>
+	$handles = get_option('rt_scripts_optimizer_skip_css_concatination_handles');
+?>
 
 	<input type="text"
 		id="rt_optimizer_skip_css_concatination_handles"
 		name="rt_scripts_optimizer_skip_css_concatination_handles"
-		value="<?php echo esc_attr( $handles ); ?>"
-		style="width:80%;"
-	>
+		value="<?php echo esc_attr($handles); ?>"
+		style="width:80%;">
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Disable CSS concatination of the supplied handles. If the skip all concatination checkbox is checked then these values will have no effect.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Disable CSS concatenation of the supplied handles. If the skip all concatenation checkbox is checked then these values will have no effect.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
 }
+
+
 
 /**
  * Field callback to accept paths of scripts to exclude.
  *
  * @param array $args arguments passed.
  */
-function rt_scripts_optimizer_paths_field_callback( $args ) {
+function rt_scripts_optimizer_paths_field_callback($args)
+{
 
 	// option value.
-	$paths = get_option( 'rt_scripts_optimizer_exclude_paths' );
-	?>
+	$paths = get_option('rt_scripts_optimizer_exclude_paths');
+?>
 
 	<input type="text"
 		id="rt_optimizer_paths"
 		name="rt_scripts_optimizer_exclude_paths"
-		value="<?php echo esc_attr( $paths ); ?>"
-		style="width:80%;"
-	>
+		value="<?php echo esc_attr($paths); ?>"
+		style="width:80%;">
 
 	<br>
 
 	<p class='description'>
-		<?php esc_html_e( 'Adding script path to this field will exclude them from optimizer and load them normally.', 'RT_Script_Optimizer' ); ?>
+		<?php esc_html_e('Adding script path to this field will exclude them from optimizer and load them normally.', 'RT_Script_Optimizer'); ?>
 	</p>
-	<?php
+<?php
+}
+
+/**
+ * Field callback to disable JS optimizations.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_disable_js_optimizations_callback($args)
+{
+
+	// option value.
+	$disable_js_optimizations = get_option('rt_scripts_optimizer_disable_js_optimizations', '1');
+?>
+
+	<input type="checkbox" id="rt_optimizer_disable_js_optimizations" name="rt_scripts_optimizer_disable_js_optimizations" value="1" <?php checked($disable_js_optimizations, '1', true); ?>>
+	<p class='description'>
+		<?php esc_html_e('Check this to disable all JS optimizations.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
+}
+
+/**
+ * Field callback to disable CSS optimizations.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_disable_css_optimizations_callback($args)
+{
+
+	// option value.
+	$disable_css_optimizations = get_option('rt_scripts_optimizer_disable_css_optimizations', '1');
+?>
+
+	<input type="checkbox" id="rt_optimizer_disable_css_optimizations" name="rt_scripts_optimizer_disable_css_optimizations" value="1" <?php checked($disable_css_optimizations, '1', true); ?>>
+	<p class='description'>
+		<?php esc_html_e('Check this to disable all CSS optimizations.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
+}
+
+/**
+ * Field callback to accept handles of stylesheets which are to be commented out.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_comment_out_style_handles_callback($args)
+{
+
+	// option value.
+	$handles = get_option('rt_scripts_optimizer_comment_out_style_handles');
+?>
+
+	<input type="text" id="rt_optimizer_comment_out_style_handles" name="rt_scripts_optimizer_comment_out_style_handles" value="<?php echo esc_attr($handles); ?>" style="width:80%;">
+
+	<br>
+
+	<p class='description'>
+		<?php esc_html_e('Adding stylesheets\' handle here will make them be commented out in the HTML.', 'RT_Script_Optimizer'); ?>
+	</p>
+<?php
 }
 
 // Add action to add options page.
-add_action( 'admin_menu', 'rt_scripts_optimizer_options_submenu' );
+add_action('admin_menu', 'rt_scripts_optimizer_options_submenu');
 
 /**
  * Option page submenu callback.
  */
-function rt_scripts_optimizer_options_submenu() {
+function rt_scripts_optimizer_options_submenu()
+{
 
 	add_options_page(
-		__( 'RT Scripts Optimizer', 'RT_Script_Optimizer' ),
-		__( 'RT Scripts Optimizer', 'RT_Script_Optimizer' ),
+		__('RT Scripts Optimizer', 'RT_Script_Optimizer'),
+		__('RT Scripts Optimizer', 'RT_Script_Optimizer'),
 		'manage_options',
 		'rt-scripts-optimizer-settings',
 		'rt_scripts_optimizer_settings_template'
 	);
-
 }
 
 
 /**
  * Top level menu callback function
  */
-function rt_scripts_optimizer_settings_template() {
+function rt_scripts_optimizer_settings_template()
+{
 
 	// check if user can edit the setting.
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if (! current_user_can('manage_options')) {
 		return;
 	}
 
-	?>
-	<div>
+?>
+	<div class="wrap">
 		<h1>
-			<?php echo esc_html( get_admin_page_title() ); ?>
+			<?php echo esc_html(get_admin_page_title()); ?>
 		</h1>
-		<br><br>
+
+		<style>
+			.rt-optimizer-section-wrapper {
+				background: #fff;
+				border: 1px solid #c3c4c6;
+				border-radius: 4px;
+				box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+				margin-top: 20px;
+				padding: 0;
+			}
+
+			.rt-optimizer-section-wrapper h2 {
+				font-size: 1.1em;
+				margin: 0;
+				padding: 1em 1.5em;
+				border-bottom: 1px solid #c3c4c6;
+			}
+
+			.rt-optimizer-section-wrapper .form-table {
+				margin: 0;
+				padding: 1em 1.5em;
+			}
+
+			.rt-optimizer-section-wrapper .form-table tr:not(:first-of-type) {
+				border-left: 4px solid #7e8993;
+			}
+
+			.rt-optimizer-section-wrapper .form-table tr:not(:first-of-type) th,
+			.rt-optimizer-section-wrapper .form-table tr:not(:first-of-type) td {
+				padding-left: 25px;
+			}
+		</style>
+
 		<form action="options.php" method="post">
 			<?php
 
 			// output settings fields for the registered setting "RT_Script_Optimizer".
-			settings_fields( 'rt-scripts-optimizer-settings' );
+			settings_fields('rt-scripts-optimizer-settings');
 
-			// setting sections and their fields.
-			do_settings_sections( 'rt-scripts-optimizer-settings' );
+			// Manually render sections to add wrapper div and avoid FOUC.
+			global $wp_settings_sections, $wp_settings_fields;
+			$page = 'rt-scripts-optimizer-settings';
+
+			if (!isset($wp_settings_sections[$page])) {
+				return;
+			}
+
+			foreach ((array) $wp_settings_sections[$page] as $section) {
+				echo '<div class="rt-optimizer-section-wrapper">';
+
+				if ($section['title']) {
+					echo '<h2>' . esc_html($section['title']) . '</h2>' . "\n";
+				}
+
+				if ($section['callback']) {
+					call_user_func($section['callback'], $section);
+				}
+
+				if (!isset($wp_settings_fields) || !isset($wp_settings_fields[$page]) || !isset($wp_settings_fields[$page][$section['id']])) {
+					echo '</div>';
+					continue;
+				}
+
+				echo '<table class="form-table" role="presentation">';
+				do_settings_fields($page, $section['id']);
+				echo '</table>';
+
+				echo '</div>';
+			}
 
 			// output save settings button.
-			submit_button( __( 'Save Settings', 'RT_Script_Optimizer' ) );
+			submit_button(__('Save Settings', 'RT_Script_Optimizer'));
 
 			?>
 		</form>
 	</div>
-	<?php
+	<script>
+		jQuery(document).ready(function($) {
+			// JS Optimizations
+			const jsToggle = $('#rt_optimizer_disable_js_optimizations');
+			const jsSubOptions = jsToggle.closest('tr').nextAll();
+
+			function toggleJsOptions() {
+				if (jsToggle.is(':checked')) {
+					jsSubOptions.css('opacity', '0.5');
+					jsSubOptions.find('input, textarea, select').prop('disabled', true);
+				} else {
+					jsSubOptions.css('opacity', '1');
+					jsSubOptions.find('input, textarea, select').prop('disabled', false);
+				}
+			}
+
+			jsToggle.on('change', toggleJsOptions);
+			toggleJsOptions();
+
+			// CSS Optimizations
+			const cssToggle = $('#rt_optimizer_disable_css_optimizations');
+			const cssSubOptions = cssToggle.closest('tr').nextAll();
+
+			function toggleCssOptions() {
+				if (cssToggle.is(':checked')) {
+					cssSubOptions.css('opacity', '0.5');
+					cssSubOptions.find('input, textarea, select').prop('disabled', true);
+				} else {
+					cssSubOptions.css('opacity', '1');
+					cssSubOptions.find('input, textarea, select').prop('disabled', false);
+				}
+			}
+			cssToggle.on('change', toggleCssOptions);
+			toggleCssOptions();
+		});
+	</script>
+<?php
 }

--- a/rt-scripts-optimizer.php
+++ b/rt-scripts-optimizer.php
@@ -46,12 +46,19 @@ function rt_head_scripts() {
 		return null;
 	}
 
-	$load_amp_css = get_option( 'rt_scripts_optimizer_load_amp_boilerplate_style' );
-
-	if ( '1' === $load_amp_css ) {
-		?>
+	if ('1' !== get_option('rt_scripts_optimizer_disable_js_optimizations', '1')) {
+?>
 		<script type="text/worker" id="rtpwa">onmessage=function(e){var o=new Request(e.data,{mode:"no-cors",redirect:"follow"});fetch(o)};</script>
-		<script type="text/javascript">var x = new Worker("data:text/javascript;base64," + btoa(document.getElementById("rtpwa").textContent));</script>
+		<script type="text/javascript">
+			var x = new Worker("data:text/javascript;base64," + btoa(document.getElementById("rtpwa").textContent));
+		</script>
+	<?php
+	}
+
+	$load_amp_css = get_option('rt_scripts_optimizer_load_amp_boilerplate_style', '0');
+
+	if ('1' === $load_amp_css && '1' !== get_option('rt_scripts_optimizer_disable_css_optimizations', '1')) {
+	?>
 		<!-- Load the amp-boiler plate to show content after 0.5 seconds. Helps with CLS issue. Use selector (.site-content) of the content area after your <header> tag, so header displays always. -->
 		<style amp-boilerplate>
 			@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}
@@ -73,6 +80,10 @@ function rt_footer_scripts() {
 	if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
 		return null;
 	}
+
+	if ('1' === get_option('rt_scripts_optimizer_disable_js_optimizations', '1')) {
+		return;
+	}
 	?>
 		<script type="text/javascript">const t = ["mouseover", "keydown", "touchmove", "touchstart", "scroll"]; t.forEach(function (t) { window.addEventListener(t, e, { passive: true }) }); function e() { n(); t.forEach(function (t) { window.removeEventListener(t, e, { passive: true }) }) } function c(t, e, n) { if (typeof n === "undefined") { n = 0 } t[n](function () { n++; if (n === t.length) { e() } else { c(t, e, n) } }) } function u() { var t = document.createEvent("Event"); t.initEvent("DOMContentLoaded", true, true); window.dispatchEvent(t); document.dispatchEvent(t); var e = document.createEvent("Event"); e.initEvent("readystatechange", true, true); window.dispatchEvent(e); document.dispatchEvent(e); var n = document.createEvent("Event"); n.initEvent("load", true, true); window.dispatchEvent(n); document.dispatchEvent(n); var o = document.createEvent("Event"); o.initEvent("show", true, true); window.dispatchEvent(o); document.dispatchEvent(o); var c = window.document.createEvent("UIEvents"); c.initUIEvent("resize", true, true, window, 0); window.dispatchEvent(c); document.dispatchEvent(c); } function rti(t, e) { var n = document.createElement("script"); n.type = "text/javascript"; if (t.src) { n.onload = e; n.onerror = e; n.src = t.src; n.id = t.id } else { n.textContent = t.innerText; n.id = t.id } t.parentNode.removeChild(t); document.body.appendChild(n); if (!t.src) { e() } } function n() { var t = document.querySelectorAll("script"); var n = []; var o;[].forEach.call(t, function (e) { o = e.getAttribute("type"); if (o == "text/rtscript") { n.push(function (t) { rti(e, t) }) } }); c(n, u) }</script>
 	<?php
@@ -90,7 +101,12 @@ add_action( 'wp_footer', 'rt_footer_scripts' );
  *
  * @return string
  */
-function rt_scripts_handler( $tag, $handle, $src ) {
+function rt_scripts_handler($tag, $handle, $src)
+{
+
+	if ('1' === get_option('rt_scripts_optimizer_disable_js_optimizations', '1')) {
+		return $tag;
+	}
 
 	global $skip_js;
 
@@ -111,8 +127,8 @@ function rt_scripts_handler( $tag, $handle, $src ) {
 		return $tag;
 	}
 
-	$handles_option_array = explode( ',', get_option( 'rt_scripts_optimizer_exclude_handles' ) );
-	$paths_option_array   = explode( ',', get_option( 'rt_scripts_optimizer_exclude_paths' ) );
+	$handles_option_array = array_filter(explode(',', get_option('rt_scripts_optimizer_exclude_handles', '')));
+	$paths_option_array   = array_filter(explode(',', get_option('rt_scripts_optimizer_exclude_paths', '')));
 
 	// Get handle using the paths provided in the settings.
 	foreach ( $paths_option_array as $key => $script_path ) {
@@ -162,7 +178,11 @@ add_filter( 'script_loader_tag', 'rt_scripts_handler', 10, 3 );
  */
 function load_async_styles( $html, $handle ) {
 
-	if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
+	if ('1' === get_option('rt_scripts_optimizer_disable_css_optimizations', '1')) {
+		return $html;
+	}
+
+	if (function_exists('amp_is_request') && amp_is_request()) {
 		return $html;
 	}
 
@@ -187,12 +207,12 @@ function load_async_styles( $html, $handle ) {
 		return $async_html;
 	}
 
-	$async_js_loading = array(); // The above array can be used here also but that will cause FOUT as this script is included in the footer from where the CSS is loaded.
-	if ( ! is_admin() && in_array( $handle, $async_js_loading, true ) ) {
-		$async_html  = str_replace( 'rel=\'stylesheet\'', 'rel=\'rt-optimized-stylesheet\'', $html );
-		$async_html .= sprintf( '<noscript>%s</noscript>', $html );
-		return $async_html;
-	}
+	// $async_js_loading = array(); // The above array can be used here also but that will cause FOUT as this script is included in the footer from where the CSS is loaded.
+	// if (! is_admin() && in_array($handle, $async_js_loading, true)) {
+	// 	$async_html  = str_replace('rel=\'stylesheet\'', 'rel=\'rt-optimized-stylesheet\'', $html);
+	// 	$async_html .= sprintf('<noscript>%s</noscript>', $html);
+	// 	return $async_html;
+	// }
 
 	$optimized_loading = explode( ',', get_option( 'rt_scripts_optimizer_style_async_handles_onevent' ) );
 	if ( ! is_admin() && in_array( $handle, $optimized_loading, true ) ) {
@@ -212,6 +232,11 @@ function style_enqueue_script() {
 	if ( is_admin() ) {
 		return null;
 	}
+
+	$disable_css_optimizations = '1' === get_option('rt_scripts_optimizer_disable_css_optimizations', '1');
+	$disable_js_optimizations  = '1' === get_option('rt_scripts_optimizer_disable_js_optimizations', '1');
+
+	if (! $disable_css_optimizations) {
 	?>
 		<script type="text/javascript">
 			const s_i_e=["mousemove","keydown","touchmove","touchstart","scroll"];function s_i_e_e(){s_i(),s_i_e.forEach(function(e){window.removeEventListener(e,s_i_e_e,{passive:!0})})}function s_i_rti(e){loadCSS(e.href),e.href||s_i_e_e()}function s_i(){var e=document.querySelectorAll("link");[].forEach.call(e,function(e){"rt-optimized-onevent-stylesheet"==e.getAttribute("rel")&&s_i_rti(e)})}s_i_e.forEach(function(e){window.addEventListener(e,s_i_e_e,{passive:!0})}),function(){var e=document.querySelectorAll("link");[].forEach.call(e,function(e){"rt-optimized-stylesheet"==e.getAttribute("rel")&&loadCSS(e.href)})}();
@@ -272,7 +297,11 @@ add_action( 'wp_footer', 'style_enqueue_script' );
  */
 function dequeue_styles() {
 
-	if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
+	if ('1' === get_option('rt_scripts_optimizer_disable_css_optimizations', '1')) {
+		return;
+	}
+
+	if (function_exists('amp_is_request') && amp_is_request()) {
 		return;
 	}
 
@@ -328,7 +357,8 @@ function skip_css_concatination( $do_concat, $handle ) {
 /**
  * Disable concatination according to the supplied setting.
  */
-if ( '1' === get_option( 'rt_scripts_optimizer_skip_css_concatination_all' ) ) {
+if ('1' !== get_option('rt_scripts_optimizer_disable_css_optimizations', '1')) {
+	if ('1' === get_option('rt_scripts_optimizer_skip_css_concatination_all', '0')) {
 
 	add_filter( 'css_do_concat', '__return_false' );
 
@@ -377,7 +407,9 @@ function disable_emojis_remove_dns_prefetch( $urls, $relation_type ) {
  */
 function rt_scripts_optimizer_load_scripts() {
 
-	wp_enqueue_script( 'loadCSS', RT_SCRIPTS_OPTIMIZER_DIR_URL . '/assets/js/loadCSS.min.js', array(), filemtime( RT_SCRIPTS_OPTIMIZER_DIR_PATH . '/assets/js/loadCSS.min.js' ), false );
+	if ('1' === get_option('rt_scripts_optimizer_disable_css_optimizations', '1')) {
+		return;
+	}
 
 }
 add_action( 'wp_enqueue_scripts', 'rt_scripts_optimizer_load_scripts' );
@@ -397,7 +429,9 @@ function rt_scripts_optimizer_iframe_lazy_loading( $content ) {
 
 }
 
-add_action( 'the_content', 'rt_scripts_optimizer_iframe_lazy_loading', PHP_INT_MAX );
+if ('1' !== get_option('rt_scripts_optimizer_disable_js_optimizations', '1')) {
+	add_action('the_content', 'rt_scripts_optimizer_iframe_lazy_loading', PHP_INT_MAX);
+}
 
 /**
  * Modifies output of some of the embed blocks.
@@ -417,4 +451,6 @@ function rt_scripts_optimizer_modify_embeds( $block_content, $block ) {
 
 }
 
-add_filter( 'render_block', 'rt_scripts_optimizer_modify_embeds', 10, 2 );
+if ('1' !== get_option('rt_scripts_optimizer_disable_js_optimizations', '1')) {
+	add_filter('render_block', 'rt_scripts_optimizer_modify_embeds', 10, 2);
+}


### PR DESCRIPTION
Adds a 'Settings' link to the RT Scripts Optimizer plugin on the WordPress plugins page, providing direct access to the configuration options. Closes #7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to enable or disable JavaScript and CSS optimizations from the admin settings page.
  * Introduced toggles for commenting out specific CSS handles.

* **Improvements**
  * Enhanced the settings page with clearer UI grouping, improved styling, and dynamic interactivity for enabling/disabling related options.
  * Minor corrections in user-facing descriptions for better clarity.

* **Bug Fixes**
  * Fixed a typo in settings descriptions ("concatination" corrected to "concatenation").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->